### PR TITLE
write original_tag label as fallback when converting to digest access

### DIFF
--- a/ctt/uploaders.py
+++ b/ctt/uploaders.py
@@ -9,6 +9,7 @@ import gci.componentmodel as cm
 import oci.client
 
 import ctt.processing_model as pm
+import ctt.util as ctt_util
 
 original_ref_label_name = 'cloud.gardener.cnudie/migration/original_ref'
 
@@ -37,19 +38,15 @@ def labels_with_migration_hint(
     resource: cm.Resource,
     src_img_ref,
 ):
+    original_ref_label = cm.Label(
+        name=original_ref_label_name,
+        value=src_img_ref,
+    )
     src_labels = resource.labels or []
-    original_ref_label = [label for label in src_labels if label.name == original_ref_label_name]
-    if original_ref_label:
-        # original ref label exists --> do not overwrite it
-        return src_labels
-    else:
-        # original ref label doesn't exist --> append it
-        return src_labels + [
-            cm.Label(
-                name=original_ref_label_name,
-                value=src_img_ref,
-            ),
-        ]
+    return ctt_util.add_label(
+        src_labels=src_labels,
+        label=original_ref_label,
+    )
 
 
 def calc_tgt_tag(src_tag: str) -> str:

--- a/ctt/util.py
+++ b/ctt/util.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import typing
+
+import gci.componentmodel as cm
+
+
+# adds the defined label to a list of labels. won't overwrite existing labels with the same key
+def add_label(
+    src_labels: typing.Sequence[cm.Label],
+    label: cm.Label,
+) -> typing.Sequence[cm.Label]:
+    label_exists = [src_label for src_label in src_labels if src_label.name == label.name]
+    if label_exists:
+        # label exists --> do not overwrite it
+        return src_labels
+    else:
+        # label doesn't exist --> append it
+        return src_labels + [
+            label,
+        ]


### PR DESCRIPTION
**What this PR does / why we need it**:
write original_tag label when converting resources to digest access for enabling simple backconversion

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
- write original_tag label when converting resources to digest access
```
